### PR TITLE
Clarifying resolutions of relief grids

### DIFF
--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -66,7 +66,7 @@ def load_earth_relief(resolution="01d", region=None, registration=None, use_srtm
     Notes
     -----
     The :class:`xarray.DataArray` grid doesn't support slice operation, for
-    Earth relief data with resolutions higher than "05m", which are stored as
+    Earth relief data with resolutions with resolutions of 5 arc-minutes or higher, which are stored as
     smaller tiles.
 
     Examples

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -66,7 +66,7 @@ def load_earth_relief(resolution="01d", region=None, registration=None, use_srtm
     Notes
     -----
     The :class:`xarray.DataArray` grid doesn't support slice operation, for
-    Earth relief data with resolutions with resolutions of 5 arc-minutes or higher, which are stored as
+    Earth relief data with resolutions of 5 arc-minutes or higher, which are stored as
     smaller tiles.
 
     Examples

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -66,8 +66,8 @@ def load_earth_relief(resolution="01d", region=None, registration=None, use_srtm
     Notes
     -----
     The :class:`xarray.DataArray` grid doesn't support slice operation, for
-    Earth relief data with resolutions of 5 arc-minutes or higher, which are stored as
-    smaller tiles.
+    Earth relief data with resolutions of 5 arc-minutes or higher, which are
+    stored as smaller tiles.
 
     Examples
     --------

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -27,11 +27,17 @@ from pygmt.helpers import (
     N="no_clip",
     R="region",
     S="skip",
+    U="timestamp",
     V="verbose",
     W="pen",
     X="xshift",
     Y="yshift",
+    b="binary",
     c="panel",
+    d="nodata",
+    e="find",
+    f="coltypes",
+    h="header",
     i="incols",
     l="label",
     p="perspective",
@@ -106,9 +112,15 @@ def contour(self, x=None, y=None, z=None, data=None, **kwargs):
         to be of the format [*annotcontlabel*][/*contlabel*]. If either
         label contains a slash (/) character then use ``|`` as the
         separator for the two labels instead.
+    {U}
     {V}
     {XY}
+    {b}
     {c}
+    {d}
+    {e}
+    {f}
+    {h}
     {i}
     {p}
     {t}


### PR DESCRIPTION
**Description of proposed changes**

To clarify resolution of relief grids requiring region parameter

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes # 1375


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
